### PR TITLE
Use os.path.join for cross-platform path management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,3 @@
 Make sure Pandas is installed. Everything else is standard.
 
 Also, you should have ExifTool and Siegfried installed and on your local PATH; if not, at least have them in the same directory as exiegfried.
-
-## Limitations
-exiegfried was written for a group of Windows users, so you'll have to do some minor file-path editing to use it on a Unix-based system.

--- a/exiegfried.py
+++ b/exiegfried.py
@@ -29,19 +29,19 @@ def processor(w, x, y, z):
     else:
         print("Your folder type isn't recognized. Shutting down.")
         sys.exit()
-    extended_path = w + '\\' + x
+    extended_path = os.path.join(w, x)
     for folder in os.listdir(extended_path):
         if folder.startswith(y):
             ident = (folder.split("_")[1])[:-3]
             ident_number = folder.split("_")[2]
-            new_folder = "{0}\\{1}_{2}aip_{3}_{4}".format(
-                extended_path, folder_number, ident, ident_number, folder_type
-            )
+            new_folder = os.path.join(
+                extended_path,
+                "{0}_{1}aip_{2}_{3}".format(folder_number, ident, ident_number, folder_type))
             os.mkdir(new_folder)
             print("\n\nFolder created at: {0}\n\n".format(new_folder))
-            folder_to_be_checked = "{0}\\{1}".format(extended_path, folder)
-            exif_doc = "{0}\\{1}-exiftool.csv".format(new_folder, z)
-            sigf_doc = "{0}\\{1}-fileformats.csv".format(new_folder, z)
+            folder_to_be_checked = os.path.join(extended_path, folder)
+            exif_doc = os.path.join(new_folder, "{0}-exiftool.csv".format(z))
+            sigf_doc = os.path.join(new_folder, "{0}-fileformats.csv".format(z))
             try:
                 raw_exif = sb.check_output(
                     ["exiftool", "-j", "-r", folder_to_be_checked]


### PR DESCRIPTION
I was gonna file an issue but it was faster to just do it.  I think Python actually does a little bit of path-anonymizing by itself - I think / will be treated as dirsep by a bunch of functions just in strings, but using `os.path.join` is definitely safe.